### PR TITLE
small changes in do-like-javac to let it works on ontology checker

### DIFF
--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -39,9 +39,7 @@ def run(args, javac_commands, jars):
         if 'CLASSPATH' in os.environ:
             cp += ':' + os.environ['CLASSPATH']
 
-        cmd = CFI_command + ['-Xms1024m',
-                             '-Xmx2048m',
-                             '-classpath', cp,
+        cmd = CFI_command + ['-classpath', cp,
                              'checkers.inference.InferenceLauncher',
                              '--solverArgs', args.solverArgs,
                              '--cfArgs', args.cfArgs,

--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -17,6 +17,9 @@ infer_group.add_argument('-m', '--mode', metavar='<mode>',
 infer_group.add_argument('-solverArgs', '--solverArgs', metavar='<solverArgs>',
                         action='store',default='backEndType=maxsatbackend.MaxSat',
                         help='arguments for solver')
+infer_group.add_argument('-cfArgs', '--cfArgs', metavar='<cfArgs>',
+                        action='store',default='',
+                        help='arguments for checker framework')
 
 def run(args, javac_commands, jars):
     # the dist directory if CFI.
@@ -33,9 +36,15 @@ def run(args, javac_commands, jars):
              ':' + os.path.join(CFI_dist, 'plume.jar') + \
              ':' + os.path.join(CFI_dist, 'checker-framework-inference.jar')
 
-        cmd = CFI_command + ['-classpath', cp,
+        if 'CLASSPATH' in os.environ:
+            cp += ':' + os.environ['CLASSPATH']
+
+        cmd = CFI_command + ['-Xms1024m',
+                             '-Xmx2048m',
+                             '-classpath', cp,
                              'checkers.inference.InferenceLauncher',
                              '--solverArgs', args.solverArgs,
+                             '--cfArgs', args.cfArgs,
                              '--checker', args.checker,
                              '--solver', args.solver,
                              '--mode', args.mode,


### PR DESCRIPTION
1. add `cfArgs` option in do-like-javac

2. append system `CLASSPATH` into the classpath, which would enable us add ontology checker in system `CLASSPATH`, and then let do-like-javac load ontology checker through system `CLASSPATH`. This pattern is general for all third party checkers.