### PR TITLE
use relative path of JSR308.

### DIFF
--- a/do_like_javac/tools/check.py
+++ b/do_like_javac/tools/check.py
@@ -21,7 +21,7 @@ def get_tool_command(args, target_classpath, java_files):
     if 'CLASSPATH' in os.environ:
             target_classpath += ':' + os.environ['CLASSPATH']
 
-    javacheck = os.environ['JSR308']+"/checker-framework/checker/bin/javac"
+    javacheck = os.path.abspath(os.path.join(os.getcwd(), "../../../")) + "/checker-framework/checker/bin/javac"
     checker_command = [javacheck,
                        "-processor", args.checker,
                        "-classpath", target_classpath]

--- a/do_like_javac/tools/infer.py
+++ b/do_like_javac/tools/infer.py
@@ -39,7 +39,7 @@ def run(args, javac_commands, jars):
 
 def get_tool_command(args, target_classpath, java_files, jaif_file="default.jaif"):
     # the dist directory of CFI.
-    CFI_dist = os.path.join(os.environ['JSR308'], 'checker-framework-inference', 'dist')
+    CFI_dist = os.path.join(os.path.abspath(os.path.join(os.getcwd(), "../../../")), 'checker-framework-inference', 'dist')
     CFI_command = ['java']
 
     cp = target_classpath + \


### PR DESCRIPTION
Hello, I open this PR to resolve error in `./gradlew testDataflowExternalSolvers` in CFI. I change these two files to use relative path of JSR308.
To make the test work properly, opprop/checker-framework-inference#213 also need to resolve.
